### PR TITLE
Feature/sql lab string angle brackets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,13 @@ superset/translations/**/messages.json
 superset/translations/**/messages.mo
 
 docker/requirements-local.txt
+/.claude
+/.github
+/.claude
+/.cursor
+/.history
+/memory
+CLAUDE.md
 
 cache/
 docker/*local*

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -44,42 +44,86 @@ export function sanitizeHtml(htmlString: string) {
   return xssFilter.process(htmlString);
 }
 
-export function hasHtmlTagPattern(str: string): boolean {
-  const htmlTagPattern =
-    /<(html|head|body|div|span|a|p|h[1-6]|title|meta|link|script|style)/i;
-
-  return htmlTagPattern.test(str);
-}
-
-export function isProbablyHTML(text: string) {
-  const cleanedStr = text.trim().toLowerCase();
-
-  if (
-    cleanedStr.startsWith('<!doctype html>') &&
-    hasHtmlTagPattern(cleanedStr)
-  ) {
-    return true;
+/**
+ * Simplified HTML detection - extremely conservative approach.
+ * 
+ * This function now ONLY detects complete HTML documents (starting with
+ * <!DOCTYPE html> or <html>). All other strings with angle brackets will
+ * be treated as plain text and displayed as-is.
+ * 
+ * Rationale:
+ * - Query results containing strings like "<custom_tag>value</custom_tag>"
+ *   or comparison operators "a < b" should be visible as plain text
+ * - Only intentional full HTML documents should be rendered as HTML
+ * - This prevents data hiding where overly aggressive HTML sanitization
+ *   strips unrecognized tags, making query results appear empty
+ * - Users can still opt-in to HTML rendering via SqllabIsRenderHtmlEnabled,
+ *   but the default behavior is to show data as text to prevent data loss
+ * 
+ * @param text - The string to check
+ * @returns true only if the text is a complete HTML document, false otherwise
+ */
+export function isProbablyHTML(text: string): boolean {
+  if (!text || typeof text !== 'string') {
+    return false;
   }
 
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(cleanedStr, 'text/html');
-  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
+  const cleaned = text.trim().toLowerCase();
+  
+  // Only full HTML documents are treated as HTML
+  // Everything else (including HTML fragments like <div>test</div>) displays as text
+  return cleaned.startsWith('<!doctype html>') || cleaned.startsWith('<html');
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {
   return isProbablyHTML(htmlString) ? sanitizeHtml(htmlString) : htmlString;
 }
 
-export function safeHtmlSpan(possiblyHtmlString: string) {
+/**
+ * Simplified HTML rendering - returns plain strings by default.
+ * 
+ * With the simplified isProbablyHTML detection, almost all query result strings
+ * (including those with angle brackets like "<custom_tag>value</custom_tag>")
+ * will return as plain text. React will automatically escape the angle brackets,
+ * making them visible to users.
+ * 
+ * Only complete HTML documents (starting with <!DOCTYPE html> or <html>) will
+ * be sanitized and rendered as HTML.
+ * 
+ * @param possiblyHtmlString - The string that might contain HTML
+ * @returns Either the original string (for React to escape) or a JSX element with sanitized HTML
+ */
+export function safeHtmlSpan(possiblyHtmlString: string): string | JSX.Element {
+  // Input validation - handle null/undefined
+  if (!possiblyHtmlString || typeof possiblyHtmlString !== 'string') {
+    return possiblyHtmlString;
+  }
+
   const isHtml = isProbablyHTML(possiblyHtmlString);
+  
   if (isHtml) {
+    // This is a full HTML document - sanitize and render
+    const sanitized = sanitizeHtml(possiblyHtmlString);
+    
+    // Fallback: If sanitization stripped everything, display as text instead
+    if (!sanitized || sanitized.trim().length === 0) {
+      console.warn(
+        'HTML sanitization removed all content, displaying as text:',
+        possiblyHtmlString.substring(0, 100)
+      );
+      return possiblyHtmlString;
+    }
+    
     return (
       <span
         className="safe-html-wrapper"
-        dangerouslySetInnerHTML={{ __html: sanitizeHtml(possiblyHtmlString) }}
+        dangerouslySetInnerHTML={{ __html: sanitized }}
       />
     );
   }
+  
+  // Not HTML - return as-is for React to automatically escape
+  // This includes: custom tags, HTML fragments, comparison operators, JSX syntax, etc.
   return possiblyHtmlString;
 }
 

--- a/superset-frontend/src/components/FilterableTable/utils.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.tsx
@@ -30,6 +30,19 @@ type Params = CellParams & {
   getCellContent?: (args: CellParams) => string;
 };
 
+/**
+ * Renders a cell in the SQL Lab results table.
+ * 
+ * With the simplified HTML detection approach:
+ * - Strings with angle brackets (like "<custom_tag>value</custom_tag>") display as plain text
+ * - Only complete HTML documents (starting with <!DOCTYPE html> or <html>) render as HTML
+ * - This prevents data hiding where query results appear empty due to overly aggressive sanitization
+ * 
+ * @param cellData - The data to render in the cell
+ * @param getCellContent - Optional function to transform cell content
+ * @param columnKey - The column identifier
+ * @param allowHTML - Whether to allow HTML rendering (default: true)
+ */
 export const renderResultCell = ({
   cellData,
   getCellContent,
@@ -51,6 +64,9 @@ export const renderResultCell = ({
       />
     );
   }
+  // When allowHTML is true, safeHtmlSpan will:
+  // - Return strings as-is for React to escape (most cases)
+  // - Only render complete HTML documents as HTML
   if (allowHTML && typeof cellData === 'string') {
     return safeHtmlSpan(cellNode);
   }


### PR DESCRIPTION
### SUMMARY
Replaced the old `hasHtmlTagPattern` and complex fragment detection with a new `isProbablyHTML` function that only recognizes full HTML documents (starting with `<!DOCTYPE html>` or `<html>`) as HTML. All other strings are treated as plain text. This prevents data hiding and ensures that query results are always visible to users. Also, Updated the `safeHtmlSpan` function to only render sanitized HTML for complete HTML documents. If sanitization strips all content, it falls back to displaying the original string as plain text and logs a warning. For all other cases (including custom tags, fragments, or comparison operators), the string is returned as-is for React to escape.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="1904" height="956" alt="Screenshot 2025-10-26 at 02-25-47 DEV Superset" src="https://github.com/user-attachments/assets/c57920db-abad-45a4-bc72-c7138a16ff0c" />

#### AFTER
<img width="1904" height="956" alt="Screenshot 2025-10-26 at 14-30-55 DEV Superset" src="https://github.com/user-attachments/assets/acd1335e-0dbc-4678-bce3-ce5c5cfacf3a" />


### VIDEO
https://youtu.be/6ZDfeTYDrxQ

### TESTING INSTRUCTIONS
1. Open SQL Lab
2. Execute query returning strings with angle brackets (Example: `SELECT <div>test</div> as html_string` or `SELECT <my_text> as cool_text`)
3. Check results grid
4. Observe that the value is now displayed as a string literal and sanitized if necessary 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Fixes #5 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
