### PR TITLE
Feature/sort descending confusing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ docker/*local*
 test-report.html
 superset/static/stats/statistics.html
 .aider*
+/.cursor
+/.github
+/.history
+/memory

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -27,6 +27,10 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
 
+    echo "Installing zstd as prerequisite" 
+    apt update 
+    apt install -y zstd
+
     if [ "$NPM_RUN_PRUNE" = "true" ]; then
         echo "Running `npm run prune`"
         npm run prune

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -328,6 +328,30 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort descending'),
+              default: true,
+              description: t(
+                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) => {
+                // Only show in aggregation mode
+                if (!isAggMode({ controls })) {
+                  return false;
+                }
+                // Only show when a sort metric is selected
+                const sortMetric = controls?.timeseries_limit_metric?.value;
+                return sortMetric != null && 
+                  (!Array.isArray(sortMetric) || sortMetric.length > 0);
+              },
+              resetOnHide: false,
+            },
+          },
+        ],
+        [
+          {
             name: 'server_pagination',
             config: {
               type: 'CheckboxControl',
@@ -359,21 +383,6 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
-            },
-          },
-        ],
-        [
-          {
-            name: 'order_desc',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Sort descending'),
-              default: true,
-              description: t(
-                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
-              ),
-              visibility: isAggMode,
-              resetOnHide: false,
             },
           },
         ],


### PR DESCRIPTION
### SUMMARY
This pull request introduces an important update to the Superset Table chart control panel and a minor improvement to the Docker frontend build process. The main change refines the visibility logic for the "Sort descending" control, making it more context-aware.
* Enhanced the visibility logic for the `order_desc` ("Sort descending") checkbox in the Table chart's control panel (`controlPanel.tsx`). The control now only appears when aggregation mode is active and a sort metric is selected, improving the user experience by hiding irrelevant options.
* Removed the previous, less specific `order_desc` control configuration that only checked for aggregation mode, replacing it with the new, more precise logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="2560" height="1238" alt="Screenshot 2025-11-02 at 18-10-25 DEV Superset" src="https://github.com/user-attachments/assets/cc4bb8f1-7032-4591-a13d-999c36883ba0" />

#### AFTER
<img width="2557" height="1235" alt="Screenshot 2025-11-02 at 18-50-51 DEV Superset" src="https://github.com/user-attachments/assets/b1fd0a81-749b-4ca1-b2e2-892b5cee1c4e" />

### DEMO VIDEO
https://github.com/user-attachments/assets/a03e690f-1de6-4eb2-9f67-147effd5cf6a

### TESTING INSTRUCTIONS
1. Start up Superset with `docker compose` and the relevant setup steps followed
2. Navigate to Charts > Top 
3. In the control panel, do not fill in anything in the "Sort Query by" field. Observe that there is no "Sort Descending" Checkbox available
4. Drag a metric into "Sort Query By" and observe that the "Sort Descending Checkbox" appears right under this field and can now be toggled on & off


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #12 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
