### PR TITLE
Feature/fix chart browser tab title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ docker/*local*
 test-report.html
 superset/static/stats/statistics.html
 .aider*
+/.cursor
+/.github
+/.history
+/memory

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -27,6 +27,10 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
 
+    echo "Installing zstd as prerequisite" 
+    apt update 
+    apt install -y zstd
+
     if [ "$NPM_RUN_PRUNE" = "true" ]; then
         echo "Running `npm run prune`"
         npm run prune

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -299,3 +299,58 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     expect(formData[key]).toBeUndefined();
   });
 });
+
+describe('Browser Tab Title', () => {
+  beforeEach(() => {
+    // Reset document title before each test
+    document.title = 'Superset';
+  });
+
+  test('updates document title when chart has a name', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: 'Sales Dashboard',
+      },
+    };
+
+    await waitFor(() => renderWithRouter({ initialState: customState }));
+    
+    expect(document.title).toBe('Sales Dashboard - Superset');
+  });
+
+  test('keeps document title as "Superset" when chart has no name', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: null,
+      },
+    };
+
+    await waitFor(() => renderWithRouter({ initialState: customState }));
+    
+    expect(document.title).toBe('Superset');
+  });
+
+  test('resets document title to "Superset" when component unmounts', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        sliceName: 'Test Chart',
+      },
+    };
+
+    const { unmount } = await waitFor(() =>
+      renderWithRouter({ initialState: customState }),
+    );
+
+    expect(document.title).toBe('Test Chart - Superset');
+
+    unmount();
+
+    expect(document.title).toBe('Superset');
+  });
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -414,6 +414,16 @@ function ExploreViewContainer(props) {
     }
   }, []);
 
+  // Update browser tab title when viewing a chart
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = `${props.sliceName} - Superset`;
+    }
+    return () => {
+      document.title = 'Superset';
+    };
+  }, [props.sliceName]);
+
   const reRenderChart = useCallback(
     controlsChanged => {
       const newQueryFormData = controlsChanged


### PR DESCRIPTION
### SUMMARY
This pull request introduces enhancements to the user experience in the Explore view by updating the browser tab title based on the chart being viewed. 

* Updated the `ExploreViewContainer` component to dynamically set the browser tab title to the chart name when viewing a chart, and reset it to "Superset" when the component unmounts or no chart name is present.
* Added new tests in `ExploreViewContainer.test.tsx` to verify that the browser tab title updates correctly based on the chart name and resets appropriately.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="2557" height="1372" alt="image" src="https://github.com/user-attachments/assets/4280a517-0e1d-491a-91ad-0ce0578b08ef" />

#### AFTER
<img width="2559" height="1376" alt="image" src="https://github.com/user-attachments/assets/03c938aa-7d2f-48cf-b764-1cd85d0c46f9" />

### DEMO VIDEO
https://github.com/user-attachments/assets/a7ae5c2a-ef75-43df-b845-588eed025ec4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [x] Fixes: #10 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
