### PR TITLE
add SQL Button & RBAC controls to this button & View in SQL Lab in Ex…

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -56,6 +56,7 @@ import { MenuKeys, RootState } from 'src/dashboard/types';
 import DrillDetailModal from 'src/components/Chart/DrillDetail/DrillDetailModal';
 import { usePermissions } from 'src/hooks/usePermissions';
 import Button from 'src/components/Button';
+import { getCanOpenInSqlLab } from 'src/dashboard/util/permissionUtils';
 import { useCrossFiltersScopingModal } from '../nativeFilters/FilterBar/CrossFilters/ScopingModal/useCrossFiltersScopingModal';
 import { ViewResultsModalTrigger } from './ViewResultsModalTrigger';
 
@@ -182,6 +183,8 @@ const SliceHeaderControls = (
       ?.behaviors?.includes(Behavior.InteractiveChart);
   const canExplore = props.supersetCanExplore;
   const { canDrillToDetail, canViewQuery, canViewTable } = usePermissions();
+  const user = useSelector<RootState, RootState['user']>(state => state.user);
+  const canOpenInSqlLab = getCanOpenInSqlLab(user);
   const refreshChart = () => {
     if (props.updatedDttm) {
       props.forceRefresh(props.slice.slice_id, props.dashboardId);
@@ -392,7 +395,12 @@ const SliceHeaderControls = (
               <div data-test="view-query-menu-item">{t('View query')}</div>
             }
             modalTitle={t('View query')}
-            modalBody={<ViewQueryModal latestQueryFormData={props.formData} />}
+            modalBody={
+              <ViewQueryModal
+                latestQueryFormData={props.formData}
+                canOpenInSqlLab={canOpenInSqlLab}
+              />
+            }
             draggable
             resizable
             responsive

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -70,6 +70,30 @@ export function userHasPermission(
   );
 }
 
+/**
+ * Derives whether the current user can open queries in SQL Lab based on RBAC.
+ *
+ * This is intentionally coupled to the existing "menu access on SQL Lab" permission
+ * (permission `menu_access` on view `SQL Lab`). If permission context is missing or
+ * incomplete, this helper fails safe by returning false so that SQL Lab entry points
+ * such as the "View in SQL Lab" button are hidden.
+ */
+export function getCanOpenInSqlLab(
+  user?: UserWithPermissionsAndRoles | UndefinedUser | null,
+): boolean {
+  if (!user) {
+    return false;
+  }
+
+  // `userHasPermission` already treats non-privileged / anonymous users as false and
+  // returns true for admins, which keeps behavior aligned with the main navigation.
+  return userHasPermission(
+    (user as UserWithPermissionsAndRoles) ?? ({} as UndefinedUser),
+    'SQL Lab',
+    'menu_access',
+  );
+}
+
 export const canUserSaveAsDashboard = (
   dashboard: Dashboard,
   user?: UserWithPermissionsAndRoles | UndefinedUser | null,

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -34,6 +34,7 @@ import { applyColors, resetColors } from 'src/utils/colorScheme';
 import ReportModal from 'src/features/reports/ReportModal';
 import DeleteModal from 'src/components/DeleteModal';
 import { deleteActiveReport } from 'src/features/reports/ReportModal/actions';
+import { getCanOpenInSqlLab } from 'src/dashboard/util/permissionUtils';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 import { useExploreMetadataBar } from './useExploreMetadataBar';
 
@@ -168,6 +169,8 @@ export const ExploreChartHeader = ({
     [redirectSQLLab, history],
   );
 
+  const canOpenInSqlLab = getCanOpenInSqlLab(user);
+
   const [menu, isDropdownVisible, setIsDropdownVisible] =
     useExploreAdditionalActionsMenu(
       latestQueryFormData,
@@ -179,6 +182,7 @@ export const ExploreChartHeader = ({
       metadata?.dashboards,
       showReportModal,
       setCurrentReportDeleting,
+      canOpenInSqlLab,
     );
 
   const metadataBar = useExploreMetadataBar(metadata, slice);

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC, useEffect, useState } from 'react';
+import { FC, MouseEvent, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import {
   styled,
@@ -25,11 +27,16 @@ import {
   getClientErrorObject,
 } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
-import { getChartDataRequest } from 'src/components/Chart/chartAction';
+import {
+  getChartDataRequest,
+  redirectSQLLab,
+} from 'src/components/Chart/chartAction';
+import Button from 'src/components/Button';
 import ViewQuery from 'src/explore/components/controls/ViewQuery';
 
 interface Props {
   latestQueryFormData: object;
+  canOpenInSqlLab?: boolean;
 }
 
 type Result = {
@@ -43,10 +50,18 @@ const ViewQueryModalContainer = styled.div`
   flex-direction: column;
 `;
 
+const ButtonRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
 const ViewQueryModal: FC<Props> = props => {
   const [result, setResult] = useState<Result[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const dispatch = useDispatch();
+  const history = useHistory();
 
   const loadChartData = (resultType: string) => {
     setIsLoading(true);
@@ -76,6 +91,15 @@ const ViewQueryModal: FC<Props> = props => {
     loadChartData('query');
   }, [JSON.stringify(props.latestQueryFormData)]);
 
+  const handleOpenInSqlLab = (event: MouseEvent<HTMLButtonElement>) => {
+    if (!props.canOpenInSqlLab) {
+      return;
+    }
+    const openInNewWindow = event.metaKey || event.ctrlKey;
+    const historyOrUndefined = openInNewWindow ? undefined : history;
+    dispatch(redirectSQLLab(props.latestQueryFormData, historyOrUndefined));
+  };
+
   if (isLoading) {
     return <Loading />;
   }
@@ -89,6 +113,11 @@ const ViewQueryModal: FC<Props> = props => {
         item.query ? (
           <ViewQuery sql={item.query} language={item.language || undefined} />
         ) : null,
+      )}
+      {props.canOpenInSqlLab && (
+        <ButtonRow>
+          <Button onClick={handleOpenInSqlLab}>{t('View in SQL Lab')}</Button>
+        </ButtonRow>
       )}
     </ViewQueryModalContainer>
   );

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -118,6 +118,7 @@ export const useExploreAdditionalActionsMenu = (
   dashboards,
   showReportModal,
   setCurrentReportDeleting,
+  canOpenInSqlLab,
   ...rest
 ) => {
   const theme = useTheme();
@@ -425,14 +426,17 @@ export const useExploreAdditionalActionsMenu = (
             }
             modalTitle={t('View query')}
             modalBody={
-              <ViewQueryModal latestQueryFormData={latestQueryFormData} />
+              <ViewQueryModal
+                latestQueryFormData={latestQueryFormData}
+                canOpenInSqlLab={canOpenInSqlLab}
+              />
             }
             draggable
             resizable
             responsive
           />
         </Menu.Item>
-        {datasource && (
+        {datasource && canOpenInSqlLab && (
           <Menu.Item key={MENU_KEYS.RUN_IN_SQL_LAB}>
             {t('Run in SQL Lab')}
           </Menu.Item>
@@ -449,6 +453,7 @@ export const useExploreAdditionalActionsMenu = (
       latestQueryFormData,
       showReportSubMenu,
       slice,
+      canOpenInSqlLab,
       theme.gridUnit,
     ],
   );


### PR DESCRIPTION
### SUMMARY
This pull request introduces a new permission check to ensure that only users with appropriate access can open queries in SQL Lab from both the dashboard and explore views. The changes consistently propagate this permission through relevant components and hooks, updating modal dialogs and menus to conditionally show "View in SQL Lab" options based on user permissions.

**Permission logic and propagation:**

* Added the `getCanOpenInSqlLab` helper to `permissionUtils.ts` to determine if the current user has "menu_access" for SQL Lab, and updated components to use this check. [[1]](diffhunk://#diff-90563445c455927bce2e46ced4deeda68de8ded1ab44206dee1ee0df92f522c3R73-R96) [[2]](diffhunk://#diff-0bfb3304e2c6c06116fbc71ed6844bf745ffbae184e64ee777af224f6df483f9R59) [[3]](diffhunk://#diff-053cd50a9b3592e948a7bb79cda6a0a1bef81cddaf12eabf93e97dda27e649dbR37)
* Passed the `canOpenInSqlLab` flag through dashboard and explore components (`SliceHeaderControls`, `ExploreChartHeader`, `useExploreAdditionalActionsMenu`) to control access to SQL Lab entry points. [[1]](diffhunk://#diff-0bfb3304e2c6c06116fbc71ed6844bf745ffbae184e64ee777af224f6df483f9R186-R187) [[2]](diffhunk://#diff-053cd50a9b3592e948a7bb79cda6a0a1bef81cddaf12eabf93e97dda27e649dbR172-R173) [[3]](diffhunk://#diff-053cd50a9b3592e948a7bb79cda6a0a1bef81cddaf12eabf93e97dda27e649dbR185) [[4]](diffhunk://#diff-888cc9d72e504a2c52077bddadbadbcbce423d45adffa6b53e0bd8888589a330R121) [[5]](diffhunk://#diff-888cc9d72e504a2c52077bddadbadbcbce423d45adffa6b53e0bd8888589a330R456)

**UI updates for permission-based access:**

* Updated the `ViewQueryModal` component to accept `canOpenInSqlLab`, and conditionally render a "View in SQL Lab" button that dispatches a redirect action if the user has permission. [[1]](diffhunk://#diff-2e88493523381b967be191c50a05fe0e61642f068e3b5c981df1bb081549b83cL28-R39) [[2]](diffhunk://#diff-2e88493523381b967be191c50a05fe0e61642f068e3b5c981df1bb081549b83cR53-R64) [[3]](diffhunk://#diff-2e88493523381b967be191c50a05fe0e61642f068e3b5c981df1bb081549b83cR94-R102) [[4]](diffhunk://#diff-2e88493523381b967be191c50a05fe0e61642f068e3b5c981df1bb081549b83cR117-R121)
* Modified modal dialogs in dashboard and explore views to pass the `canOpenInSqlLab` prop to `ViewQueryModal`, ensuring permission-based rendering. [[1]](diffhunk://#diff-0bfb3304e2c6c06116fbc71ed6844bf745ffbae184e64ee777af224f6df483f9L395-R403) [[2]](diffhunk://#diff-888cc9d72e504a2c52077bddadbadbcbce423d45adffa6b53e0bd8888589a330L428-R439)

**Menu item visibility:**

* Updated the explore additional actions menu to only show the "Run in SQL Lab" menu item if the user has permission, aligning menu options with RBAC.

These changes improve security and user experience by ensuring SQL Lab entry points are only available to authorized users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

**Admin**
<img width="2560" height="1237" alt="image" src="https://github.com/user-attachments/assets/e59aef05-c8ff-4eea-9e1c-0e5d5c8bf1c9" />

**Gamma (no permissions to SQL Lab)**
<img width="2560" height="1237" alt="image" src="https://github.com/user-attachments/assets/8d4e94de-d799-4d20-a612-0d62667fdc33" />

#### AFTER

**Admin**
<img width="2560" height="1237" alt="image" src="https://github.com/user-attachments/assets/2902768e-cad8-4d0d-b57d-d09d436163bb" />

**Gamma  (no permissions to SQL Lab)**
<img width="2560" height="1237" alt="image" src="https://github.com/user-attachments/assets/073addf0-7238-4cf7-9318-cbe8c1a346e8" />
<img width="2560" height="1237" alt="image" src="https://github.com/user-attachments/assets/1bcab816-2d24-4c98-a80f-b74cb8681706" />

### DEMO VIDEO
https://github.com/user-attachments/assets/713895a0-fd34-4d4a-b201-3c47a71a83ce


### TESTING INSTRUCTIONS
1. Create two test user accounts: one with SQL Lab access and one 
2. Log in as the user WITH SQL Lab access
3. Open a dashboard, click on a chart's ellipsis menu, and select "View query"
4. Confirm the "View in SQL Lab" button is visible
5. Click on the chart and click on the three dots on the top right-hand corner
6. Verify that the "Run in SQL Lab" option is available
7. Log out and log in as the user WITHOUT SQL Lab access
8. Repeat steps 3-4 
9. Confirm the "View in SQL Lab" button is NOT visible, but the Copy button and other modal elements are still present
10. Click on the chart and click on the three dots; verify that the "Run in SQL Lab" option is NOT available.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #14 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
