### PR TITLE
fix query history completion time

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -333,6 +333,7 @@ export type Query = {
   endDttm: number;
   duration: string;
   startDttm: number;
+  startRunningDttm?: number;
   time: Record<string, any>;
   user: Record<string, any>;
   userId: number;

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -247,8 +247,9 @@ const QueryTable = ({
         const status = statusAttributes[state] || statusAttributes.error;
 
         if (q.endDttm) {
+          const startTime = q.startRunningDttm || q.startDttm;
           q.duration = (
-            <Label monospace>{fDuration(q.startDttm, q.endDttm)}</Label>
+            <Label monospace>{fDuration(startTime, q.endDttm)}</Label>
           );
         }
         q.user = (

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -182,6 +182,7 @@ class Query(
             "sql": self.sql,
             "sqlEditorId": self.sql_editor_id,
             "startDttm": self.start_time,
+            "startRunningDttm": self.start_running_time,
             "state": self.status.lower(),
             "tab": self.tab_name,
             "tempSchema": self.tmp_schema_name,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pull request introduces an enhancement to query timing accuracy by including the new `startRunningDttm` field, which represents the precise start time when a query begins running. The changes ensure that query duration calculations use this more accurate timestamp when available, improving the reliability of query performance metrics.

**Query timing improvements:**

* Added the optional `startRunningDttm` field to the `Query` type in `Query.ts` to track the actual running start time of queries.
* Updated the query duration calculation in `QueryTable/index.tsx` to use `startRunningDttm` if present, falling back to `startDttm` otherwise, for more accurate duration reporting.
* Modified the `to_dict` method in `sql_lab.py` to include the `startRunningDttm` value when serializing query objects.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### BEFORE
<img width="2170" height="1182" alt="image" src="https://github.com/user-attachments/assets/22567385-39bc-4dfd-a18a-db0f1157cb4b" />
<img width="2174" height="1179" alt="image" src="https://github.com/user-attachments/assets/399d825a-c853-496d-8be3-d30f277367bd" />

#### AFTER
<img width="2167" height="1174" alt="image" src="https://github.com/user-attachments/assets/6602c227-60bf-49e4-8a46-2e73c22ebf24" />

### DEMO VIDEO
https://github.com/user-attachments/assets/e5047df2-f7a9-4c46-beab-0df4b3629495


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Start Superset and navigate to SQL 
2. Execute multiple queries with different complexity levels
3. Open the Query History tab
4. Verify that duration values are reasonable and reflect actual execution time (or at least a lower execution time)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #15 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
